### PR TITLE
Proper dash versions sorting

### DIFF
--- a/J-Runner/MainForm.cs
+++ b/J-Runner/MainForm.cs
@@ -4702,7 +4702,7 @@ namespace JRunner
                     {
                         if (regex.IsMatch(Path.GetFileNameWithoutExtension(a))) variables.dashes_all.Add(Path.GetFileNameWithoutExtension(a));
                     }
-                    variables.dashes_all.Sort();
+                    variables.dashes_all.Sort((a, b) => Convert.ToInt32(a) - Convert.ToInt32(b));
                     if (variables.debugme) Console.WriteLine("Checking dashes");
                     foreach (string valueName in variables.dashes_all)
                     {


### PR DESCRIPTION
Same as in J-Runner with Extras, dash versions are sorted using string sorting instead of integer sorting. This fix puts dash versions in a properly sorted list